### PR TITLE
Handle missing seasons field in watched shows

### DIFF
--- a/trakt_plex_sync/trakt_played.py
+++ b/trakt_plex_sync/trakt_played.py
@@ -36,7 +36,7 @@ def watched_shows_guids() -> set[str]:
 
     guids = set()
     for entry in entries:
-        for season in entry["seasons"]:
+        for season in entry.get("seasons", []):
             for episode in season["episodes"]:
                 for service in ["imdb", "tmdb", "tvdb"]:
                     guids.add(


### PR DESCRIPTION
## Summary
Added defensive programming to handle cases where the `seasons` field may be missing from show entries in the watched shows data.

## Key Changes
- Modified `watched_shows_guids()` to use `.get("seasons", [])` instead of direct dictionary access
- This prevents `KeyError` exceptions when processing show entries that lack a `seasons` field
- Falls back to an empty list if the field is not present, allowing the loop to continue safely

## Implementation Details
The change uses Python's dictionary `.get()` method with a default empty list, ensuring the code gracefully handles malformed or incomplete data structures without crashing.

https://claude.ai/code/session_019TLLUT8ttnUWQA96MUXbyz