### PR TITLE
Add pagination support to Trakt API requests

### DIFF
--- a/trakt_plex_sync/trakt_played.py
+++ b/trakt_plex_sync/trakt_played.py
@@ -1,6 +1,7 @@
 import json
 import os
 import time
+import urllib.parse
 import urllib.request
 from importlib.metadata import version
 from typing import Any
@@ -17,11 +18,11 @@ _HTTP_HEADERS = {
 
 _MAX_RETRIES = 3
 _RETRY_DELAY_SECONDS = 2
+_PAGE_LIMIT = 250
 
 
 def watched_movie_guids() -> set[str]:
-    url = "https://api.trakt.tv/users/me/watched/movies"
-    entries = _get_json_with_retry(url, _MAX_RETRIES)
+    entries = _get_all_pages("https://api.trakt.tv/users/me/watched/movies")
 
     guids = set()
     for entry in entries:
@@ -31,13 +32,17 @@ def watched_movie_guids() -> set[str]:
 
 
 def watched_shows_guids() -> set[str]:
-    url = "https://api.trakt.tv/users/me/watched/shows"
-    entries = _get_json_with_retry(url, _MAX_RETRIES)
+    entries = _get_all_pages(
+        "https://api.trakt.tv/users/me/watched/shows",
+        {"extended": "progress"},
+    )
 
     guids = set()
     for entry in entries:
-        for season in entry.get("seasons", []):
+        for season in entry["seasons"]:
             for episode in season["episodes"]:
+                if episode.get("completed") is False:
+                    continue
                 for service in ["imdb", "tmdb", "tvdb"]:
                     guids.add(
                         "{}://{}/s{:02d}e{:02d}".format(
@@ -54,15 +59,33 @@ def watched_guids() -> set[str]:
     return watched_movie_guids().union(watched_shows_guids())
 
 
-def _get_json(url: str) -> Any:
+def _get_all_pages(url: str, params: dict[str, str] | None = None) -> list[Any]:
+    query: dict[str, str] = dict(params or {})
+    query["limit"] = str(_PAGE_LIMIT)
+
+    entries: list[Any] = []
+    page = 1
+    page_count = 1
+    while page <= page_count:
+        query["page"] = str(page)
+        page_url = f"{url}?{urllib.parse.urlencode(query)}"
+        body, page_count = _get_json_with_retry(page_url, _MAX_RETRIES)
+        assert isinstance(body, list)
+        entries.extend(body)
+        page += 1
+    return entries
+
+
+def _get_json(url: str) -> tuple[Any, int]:
     req = urllib.request.Request(url, headers=_HTTP_HEADERS)
     with urllib.request.urlopen(req, timeout=10) as response:
         data = response.read()
         assert isinstance(data, bytes)
-        return json.loads(data)
+        page_count = int(response.headers.get("X-Pagination-Page-Count") or "1")
+        return json.loads(data), page_count
 
 
-def _get_json_with_retry(url: str, count: int) -> Any:
+def _get_json_with_retry(url: str, count: int) -> tuple[Any, int]:
     last_error: TimeoutError | None = None
     for attempt in range(1, count + 1):
         try:


### PR DESCRIPTION
## Summary
This PR adds pagination support to Trakt API requests to handle large result sets that exceed the API's per-page limit. Previously, the code only fetched the first page of results, which could miss watched movies and shows.

## Key Changes
- Added `_get_all_pages()` function to handle paginated API requests with configurable query parameters
- Modified `_get_json()` and `_get_json_with_retry()` to return both the response body and page count from the `X-Pagination-Page-Count` header
- Updated `watched_movie_guids()` to use the new pagination function
- Updated `watched_shows_guids()` to:
  - Use the new pagination function with `extended=progress` parameter for detailed episode data
  - Filter out unwatched episodes by checking the `completed` field
  - Simplify season iteration by removing unnecessary `.get()` call
- Added `_PAGE_LIMIT` constant set to 250 (Trakt API's maximum per-page limit)
- Added `urllib.parse` import for URL query string encoding

## Implementation Details
- The pagination loop continues until all pages are fetched by comparing the current page number against the page count from the API response
- Query parameters are properly URL-encoded using `urllib.parse.urlencode()`
- The function accumulates results from all pages into a single list before returning

https://claude.ai/code/session_019TLLUT8ttnUWQA96MUXbyz