### PR TITLE
Fix Trakt token refresh workflow

### DIFF
--- a/.github/workflows/trakt.yml
+++ b/.github/workflows/trakt.yml
@@ -13,18 +13,28 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.GH_APP_ID }}
+          client-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Refresh Trakt token
         run: |
-          curl --silent --fail \
-              -X POST \
-              -F "client_id=$TRAKT_CLIENT_ID" \
-              -F "client_secret=$TRAKT_CLIENT_SECRET" \
-              -F "refresh_token=$TRAKT_REFRESH_TOKEN" \
-              -F "grant_type=refresh_token" \
-            'https://api.trakt.tv/oauth/token' >token.json
+          jq --null-input \
+            --arg client_id "$TRAKT_CLIENT_ID" \
+            --arg client_secret "$TRAKT_CLIENT_SECRET" \
+            --arg refresh_token "$TRAKT_REFRESH_TOKEN" \
+            '{
+              client_id: $client_id,
+              client_secret: $client_secret,
+              refresh_token: $refresh_token,
+              grant_type: "refresh_token"
+            }' \
+            | curl --silent --show-error --fail-with-body \
+                -X POST \
+                -H 'Content-Type: application/json' \
+                --data @- \
+                'https://api.trakt.tv/oauth/token' >token.json
+
+          jq --exit-status '.access_token and .refresh_token' token.json >/dev/null
         env:
           TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
           TRAKT_CLIENT_SECRET: ${{ secrets.TRAKT_CLIENT_SECRET }}


### PR DESCRIPTION
### Motivation
- The workflow produced a deprecation warning for the GitHub App input and the previous form-encoded `curl` refresh would exit with code 22 and hide API error bodies, so the job failed to refresh and update secrets reliably.
- The goal is to make the refresh step explicit, robust, and to verify that both `access_token` and `refresh_token` are present before updating repository secrets.

### Description
- Replace the deprecated `app-id` input with `client-id` for the `actions/create-github-app-token` step in `.github/workflows/trakt.yml`.
- Change the Trakt OAuth refresh request to emit a JSON body using `jq --null-input` and send it with `curl` using `-H 'Content-Type: application/json'` and `--data @-`.
- Add `curl --show-error --fail-with-body` so API error responses are surfaced instead of being lost behind an exit code.
- Validate the response with `jq --exit-status '.access_token and .refresh_token' token.json` before attempting to update GitHub secrets.

### Testing
- Parsed all workflow YAML files with `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/*.yml` which succeeded.
- Attempted to validate workflows with a Python script using `yaml.safe_load`, but the environment lacks the `yaml` module so that check failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5836b786488326a51f526a29b8acc4)