### PR TITLE
Fix Ruff 0.16 lint violations in plex_library.py

### DIFF
--- a/trakt_plex_sync/plex_library.py
+++ b/trakt_plex_sync/plex_library.py
@@ -1,9 +1,14 @@
 import os
 from collections.abc import Iterator
+from functools import partial
 
 import lru_cache
 from plexapi.myplex import MyPlexAccount
 from plexapi.video import Video
+
+
+def _guid_ids(video: Video) -> set[str]:
+    return {guid.id for guid in video.guids}
 
 
 def videos() -> Iterator[tuple[set[str], Video]]:
@@ -22,17 +27,13 @@ def videos() -> Iterator[tuple[set[str], Video]]:
 
     with cache:
         for movie in plex.library.section("Movies").all():
-            guids = cache.get_or_load(
-                movie.guid, lambda: set(guid.id for guid in movie.guids)
-            )
+            guids = cache.get_or_load(movie.guid, partial(_guid_ids, movie))
             yield (guids, movie)
 
         for show in plex.library.section("TV Shows").all():
-            show_guids = cache.get_or_load(
-                show.guid, lambda: set(guid.id for guid in show.guids)
-            )
+            show_guids = cache.get_or_load(show.guid, partial(_guid_ids, show))
             for episode in show.episodes():
-                guids = set([f"{guid}/{episode.seasonEpisode}" for guid in show_guids])
+                guids = {f"{guid}/{episode.seasonEpisode}" for guid in show_guids}
                 yield (guids, episode)
 
 


### PR DESCRIPTION
### Motivation
- Prepare the codebase for `ruff==0.16.0` by resolving lint violations that would break forward compatibility.
- Eliminate generator/list patterns and deferred loop-variable closures that newer Ruff rules flag as issues.

### Description
- Add a typed helper `def _guid_ids(video: Video) -> set[str]:` that returns GUID ids using a set comprehension. 
- Replace deferred loop-variable lambdas with `functools.partial(_guid_ids, ...)` to avoid closure binding warnings while preserving lazy cache loading. 
- Convert the episode GUID list-to-set conversion into a direct set comprehension and add the necessary `from functools import partial` import.

### Testing
- Attempt to run `uvx --from ruff==0.16.0 ruff ...` failed because the environment could not download `ruff==0.16.0` from PyPI. 
- Ran `ruff format --preview --check .` and `ruff check --preview .` during development to locate issues and then verified `ruff format --check .` and `ruff check .` after fixes, all of which succeeded. 
- Ran `uv run mypy .` and `git diff --check`, both of which succeeded with no remaining issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e67c1c23c8326a78301cbd0769669)